### PR TITLE
Use GitHub Actions for multi-arch Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/galactus
+          images: ${{ secrets.DOCKERHUB_REPOSITORY }}
           tag-sha: true
 
       - name: Set up QEMU

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,47 @@
+name: Build and publish Docker images
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - '*.*.*'
+    pull_request:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/galactus
+          tag-sha: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/386,linux/arm/v7,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
You can see an example of this in action [here](https://github.com/Almighty-Alpaca/galactus/actions) and the resulting images [here](https://hub.docker.com/r/almightyalpaca/galactus).

With the current configuration images are build for the following architectures: `linux/amd64`, `linux/386`, `linux/arm/v7`, `linux/arm64`. This will allow people to run Galactus on their Raspberry Pis. More architectures can be added, but they will increase build times (and are probably not really useful).

To use this you need to configure three [secrets](https://github.com/automuteus/galactus/settings/secrets/actions) in your repository:
- `DOCKERHUB_REPOSITORY`: The repository name to push to, e.g. `automuteus/galactus`
- `DOCKERHUB_USERNAME`: Username of your Docker Hub account
- `DOCKERHUB_TOKEN`: Docker Hub access token (can be generated [here](https://hub.docker.com/settings/security))

If this gets approved I plan to give the AutoMuteUs bot itself the same treatment so that the whole stack is built for ARM devices.