### PR TITLE
fix: make the multi-arch build faster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.18-alpine AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.18-alpine AS builder
+ARG TARGETOS
+ARG TARGETARCH
 
 # Git is required for getting the dependencies.
 # hadolint ignore=DL3018
@@ -19,6 +21,8 @@ COPY ./ ./
 RUN export TAG=$(git describe --tags "$(git rev-list --tags --max-count=1)") && \
     export COMMIT=$(git rev-parse --short HEAD) && \
     CGO_ENABLED=0 \
+    GOOS=${TARGETOS} \
+    GOARCH=${TARGETARCH} \
     go build -installsuffix 'static' \
     -ldflags="-X main.version=${TAG} -X main.commit=${COMMIT}" \
     -o /app .


### PR DESCRIPTION
**This is for `token-migrate` branch.**

Almost same changes as in `automuteus` repo, to make the multi-arch build faster: <https://github.com/automuteus/automuteus/commit/8309fc393661db32062981c920c69dad2a7152aa#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557>.